### PR TITLE
Support force path style

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This [Redmine](http://www.redmine.org) plugin makes file attachments be stored o
 * region: string aws region (activate when endpoint is not set)
 * thumb_folder: string folder where attachment thumbnails are stored; defaults to 'tmp'
 * import_folder: string folder where import files are stored temporarily; defaults to 'tmp'
+* force_path_style: boolean force to use path styled url used in s3 compatible softwares; defaults to false
 
 ## Forked From
 * https://github.com/tigrish/redmine_s3

--- a/config/s3.yml.example
+++ b/config/s3.yml.example
@@ -7,6 +7,7 @@ production:
   thumb_folder:
   import_folder:
   region:
+  force_path_style:
 
 development:
   access_key_id:
@@ -17,6 +18,7 @@ development:
   thumb_folder:
   import_folder:
   region:
+  force_path_style:
 
 # Uncomment this to run plugin tests with standart redmine script
 # test:

--- a/lib/redmica_s3/connection.rb
+++ b/lib/redmica_s3/connection.rb
@@ -14,6 +14,7 @@ module RedmicaS3
       thumb_folder:       'tmp',
       import_folder:      'tmp',
       region:             nil,
+      force_path_style:   false,
     }
 
     class << self
@@ -105,6 +106,8 @@ module RedmicaS3
           options[:endpoint] = endpoint
         elsif region.present?
           options[:region] = region
+        elsif force_path_style
+          options[:force_path_style] = force_path_style
         end
         @@conn = Aws::S3::Resource.new(options)
       end
@@ -135,6 +138,10 @@ module RedmicaS3
 
       def region
         @@s3_options[:region]
+      end
+
+      def force_path_style
+        @@s3_options[:force_path_style]
       end
     end
 

--- a/lib/redmica_s3/connection.rb
+++ b/lib/redmica_s3/connection.rb
@@ -106,7 +106,8 @@ module RedmicaS3
           options[:endpoint] = endpoint
         elsif region.present?
           options[:region] = region
-        elsif force_path_style
+        end
+        if force_path_style
           options[:force_path_style] = force_path_style
         end
         @@conn = Aws::S3::Resource.new(options)


### PR DESCRIPTION
# 概要
AWS SDK で S3 に接続する際に `force_path_style` オプションを渡せるように設定ファイルならびにコードを変更しました。

# 実装の背景
Minioに代表されるS3クローンはサブドメイン形式での接続に対応していないため、ローカル開発環境でこうしたクローンを使ってS3を再現するときには `force_path_style` オプションを有効化する必要があります。現状ではこのオプションを渡すことができないため、それを可能にするためにパッチを書きました。