### PR TITLE
Reflect Redmine-35539 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # S3 plugin for Redmine/RedMica
 
 ## Description
-This [Redmine](http://www.redmine.org) plugin makes file attachments be stored on [Amazon S3](http://aws.amazon.com/s3) rather than on the local filesystem. This is a fork for [original gem](http://github.com/tigrish/redmine_s3) and difference is that this one supports [RedMica](https://github.com/redmica/redmica) 1.0.x(compatible with Redmine 4.1.x and later)
+This [Redmine](http://www.redmine.org) plugin makes file attachments be stored on [Amazon S3](http://aws.amazon.com/s3) rather than on the local filesystem. This is a fork for [original gem](http://github.com/tigrish/redmine_s3) and difference is that this one supports [RedMica](https://github.com/redmica/redmica) 1.0.x and later(compatible with Redmine 4.1.x and later)
 
 ## Installation
 1. Make sure Redmine is installed and cd into it's root directory

--- a/init.rb
+++ b/init.rb
@@ -13,7 +13,7 @@ Redmine::Plugin.register :redmica_s3 do
   author 'Far End Technologies Corporation'
   author_url 'https://www.farend.co.jp'
 
-  version '1.0.8'
+  version '1.0.9'
   requires_redmine version_or_higher: '4.1.0'
 
   Rails.configuration.to_prepare do

--- a/lib/redmica_s3/attachment_patch.rb
+++ b/lib/redmica_s3/attachment_patch.rb
@@ -19,6 +19,11 @@ module RedmicaS3
       end
 
       module ClassMethods
+        # Claims a unique ASCII or hashed filename, yields the open file handle
+        def create_diskfile(filename, directory=nil, &block)
+          raise NoMethodError, "#{self}.#{__method__} cannot be used with redmica_s3 plugin."
+        end
+
         # Returns an ASCII or hashed filename that do not
         # exists yet in the given subdirectory
         def disk_filename(filename, directory=nil)

--- a/lib/redmica_s3/attachment_patch.rb
+++ b/lib/redmica_s3/attachment_patch.rb
@@ -36,10 +36,19 @@ module RedmicaS3
             # keep the extension if any
             ascii << $1 if filename =~ %r{(\.[a-zA-Z0-9]+)$}
           end
-          while RedmicaS3::Connection.object(File.join(directory.to_s, "#{timestamp}_#{ascii}")).exists?
-            timestamp.succ!
-          end
-          "#{timestamp}_#{ascii}"
+          directory = directory.to_s
+          result =
+            loop do
+              s3obj = RedmicaS3::Connection.object(File.join(directory, "#{timestamp}_#{ascii}"))
+              if s3obj.exists?
+                timestamp.succ!
+              else
+                # Avoid race condition: Create an empty S3 object
+                s3obj.put
+                break File.basename(s3obj.key)
+              end
+            end
+          result
         end
 
         # Deletes all thumbnails


### PR DESCRIPTION
https://www.redmine.org/issues/35539
https://www.redmine.org/projects/redmine/repository/revisions/21071/diff/trunk/app/models/attachment.rb`
`Attachment.disk_filename` has been replaced with `Attachment.create_diskfile`. However, AWS S3 Object is difficult to handle with file handles, so I fixed it as follows.
* `Attachment.create_diskfile` uses a file handle, so it intentionally raises an exception.
* `Attachment.disk_filename` creates an empty S3 object to avoid filename race conditions.