### PR TITLE
Fix LoadError during startup with Redmine trunk r21293

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -15,7 +15,7 @@ Redmine::Plugin.register :redmica_s3 do
   author 'Far End Technologies Corporation'
   author_url 'https://www.farend.co.jp'
 
-  version '1.0.10'
+  version '1.0.11'
   requires_redmine version_or_higher: '4.1.0'
 
   Redmine::Thumbnail.__send__(:include, RedmicaS3::ThumbnailPatch)

--- a/init.rb
+++ b/init.rb
@@ -1,10 +1,12 @@
-require 'redmica_s3/attachment_patch'
-require 'redmica_s3/attachments_controller_patch'
-require 'redmica_s3/import_patch'
-require 'redmica_s3/pdf_patch'
-require 'redmica_s3/thumbnail_patch'
-require 'redmica_s3/utils_patch'
-require 'redmica_s3/connection'
+curr_dirname = File.dirname(__FILE__)
+%w(
+  attachments_controller_patch
+  attachment_patch import_patch
+  pdf_patch thumbnail_patch utils_patch
+  connection
+).each do |require_file|
+  require File.join(curr_dirname, 'lib', 'redmica_s3', require_file)
+end
 
 Redmine::Plugin.register :redmica_s3 do
   name 'RedMica S3 plugin'
@@ -16,13 +18,12 @@ Redmine::Plugin.register :redmica_s3 do
   version '1.0.10'
   requires_redmine version_or_higher: '4.1.0'
 
-  Rails.configuration.to_prepare do
-    Redmine::Thumbnail.__send__(:include, RedmicaS3::ThumbnailPatch)
-    Redmine::Utils.__send__(:include, RedmicaS3::UtilsPatch)
-    Attachment.__send__(:include, RedmicaS3::AttachmentPatch)
-    Redmine::Export::PDF::ITCPDF.__send__(:include, RedmicaS3::PdfPatch)
-    Import.__send__(:include, RedmicaS3::ImportPatch)
-    AttachmentsController.__send__(:include, RedmicaS3::AttachmentsControllerPatch)
-  end
+  Redmine::Thumbnail.__send__(:include, RedmicaS3::ThumbnailPatch)
+  Redmine::Utils.__send__(:include, RedmicaS3::UtilsPatch)
+  Attachment.__send__(:include, RedmicaS3::AttachmentPatch)
+  Redmine::Export::PDF::ITCPDF.__send__(:include, RedmicaS3::PdfPatch)
+  Import.__send__(:include, RedmicaS3::ImportPatch)
+  AttachmentsController.__send__(:include, RedmicaS3::AttachmentsControllerPatch)
+
   RedmicaS3::Connection.create_bucket
 end


### PR DESCRIPTION
RedMica S3 plugin cannot run with Redmine trunk r21293. With the plugin installed, the following error occurs during startup and Redmine cannot be started.

The cause is probably the same as https://www.redmine.org/issues/32938.

```
/path/to/gems/ruby/2.7.0/gems/zeitwerk-2.5.1/lib/zeitwerk/kernel.rb:35:in `require': cannot load such file -- redmica_s3/attachment_patch (LoadError)
```

I have confirmed that this PR works on Redmine (trunk, 4.1-stable, 4.2-stable) and RedMica (stable-1.3, stable-2.0).