### PR TITLE
Psych 4: Psych::BadAlias exception when unserializing a config/s3.yml

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -15,7 +15,7 @@ Redmine::Plugin.register :redmica_s3 do
   author 'Far End Technologies Corporation'
   author_url 'https://www.farend.co.jp'
 
-  version '1.0.11'
+  version '1.0.12'
   requires_redmine version_or_higher: '4.1.0'
 
   Redmine::Thumbnail.__send__(:include, RedmicaS3::ThumbnailPatch)

--- a/lib/redmica_s3/connection.rb
+++ b/lib/redmica_s3/connection.rb
@@ -111,7 +111,10 @@ module RedmicaS3
 
       def load_options
         file = ERB.new( File.read(File.join(Rails.root, 'config', 's3.yml')) ).result
-        YAML::load( file )[Rails.env].each do |key, value|
+        # YAML.load works as YAML.safe_load if Psych >= 4.0 is installed
+        (
+          YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(file) : YAML.load(file)
+        )[Rails.env].each do |key, value|
           @@s3_options[key.to_sym] = value
         end
       end


### PR DESCRIPTION
When the plugin tries to read a YAML file like the one below, the exception `Psych::BadAlias` is raised.

```yaml
s3_default: &default
  bucket: bucket-name
  folder: folder/files
  thumb_folder: folder/thumb

development:
  <<: *default
```

Psych 4.0 uses `safe_load` by default (see https://github.com/ruby/psych/pull/487). Due to this change, config/s3.yml may raise `Psych::BadAlias` exception.
This bug can be resolved by using `unsafe_load` with Psych 4.0.