### PR TITLE
Reflect Redmine-38272 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # S3 plugin for Redmine/RedMica
 
 ## Description
-This [Redmine](http://www.redmine.org) plugin makes file attachments be stored on [Amazon S3](http://aws.amazon.com/s3) rather than on the local filesystem. This is a fork for [original gem](http://github.com/tigrish/redmine_s3) and difference is that this one supports [RedMica](https://github.com/redmica/redmica) 1.0.x and later(compatible with Redmine 4.1.x and later)
+This [Redmine](http://www.redmine.org) plugin makes file attachments be stored on [Amazon S3](http://aws.amazon.com/s3) rather than on the local filesystem. This is a fork for [original gem](http://github.com/tigrish/redmine_s3) and difference is that this one supports [RedMica](https://github.com/redmica/redmica) 2.2.2 and later(compatible with Redmine 5.0.5 and later)
 
 ## Installation
 1. Make sure Redmine is installed and cd into it's root directory

--- a/init.rb
+++ b/init.rb
@@ -15,7 +15,7 @@ Redmine::Plugin.register :redmica_s3 do
   author 'Far End Technologies Corporation'
   author_url 'https://www.farend.co.jp'
 
-  version '1.0.12'
+  version '2.0.0'
   requires_redmine version_or_higher: '5.0.5'
 
   Redmine::Thumbnail.__send__(:include, RedmicaS3::ThumbnailPatch)

--- a/init.rb
+++ b/init.rb
@@ -16,7 +16,7 @@ Redmine::Plugin.register :redmica_s3 do
   author_url 'https://www.farend.co.jp'
 
   version '1.0.12'
-  requires_redmine version_or_higher: '4.1.0'
+  requires_redmine version_or_higher: '5.0.5'
 
   Redmine::Thumbnail.__send__(:include, RedmicaS3::ThumbnailPatch)
   Redmine::Utils.__send__(:include, RedmicaS3::UtilsPatch)

--- a/lib/redmica_s3/pdf_patch.rb
+++ b/lib/redmica_s3/pdf_patch.rb
@@ -175,21 +175,20 @@ module RedmicaS3
     private
 
     def proc_image_file(src, &block)
-      tmpFile = nil
-      img_file =
-        if src.is_a?(Attachment) || src.is_a?(Array) || /^http/.match?(src)
+      if src.is_a?(Attachment) || src.is_a?(Array)
+        begin
           tmpFile = get_image_file(src)
-          tmpFile.path
-        else
-          src
+          yield tmpFile.path
+        rescue => err
+          logger.error "pdf: Image: error: #{err.message}"
+          false
+        ensure
+          # remove temp files
+          tmpFile.close(true) if tmpFile
         end
-      yield img_file
-    rescue => err
-      logger.error "pdf: Image: error: #{err.message}"
-      false
-    ensure
-      # remove temp files
-      tmpFile.close(true) if tmpFile
+      else
+        super(src, &block)
+      end
     end
   end
 end

--- a/lib/redmica_s3/pdf_patch.rb
+++ b/lib/redmica_s3/pdf_patch.rb
@@ -156,20 +156,21 @@ module RedmicaS3
     end
 
     def get_image_file(image_uri)
-      #use a temporary file....
-      tmpFile = Tempfile.new(['tmp_', '.img'], self.class.k_path_cache)
-      tmpFile.binmode
-      if image_uri.is_a?(Attachment)
-        tmpFile.write(image_uri.raw_data)
-      elsif image_uri.is_a?(Array)  # thumbnail
-        tmpFile.write(image_uri.last)
-      else
-        open(image_uri, 'rb') do |read_file|
-          tmpFile.write(read_file.read)
+      if image_uri.is_a?(Attachment) || image_uri.is_a?(Array)
+        #use a temporary file....
+        tmpFile = Tempfile.new(['tmp_', '.img'], self.class.k_path_cache)
+        tmpFile.binmode
+        if image_uri.is_a?(Attachment)
+          tmpFile.write(image_uri.raw_data)
+        else
+          # thumbnail
+          tmpFile.write(image_uri.last)
         end
+        tmpFile.fsync
+        tmpFile
+      else
+        super
       end
-      tmpFile.fsync
-      tmpFile
     end
 
     private


### PR DESCRIPTION
https://github.com/naitoh/rbpdf/releases/tag/1.21.0
https://github.com/naitoh/rbpdf/pull/58
Pull request #58 for rbpdf gem has been merged and v1.21.0 has been released.

https://www.redmine.org/issues/38272
rbpdf gem 1.21.0 has been incorporated into Redmine.

* I have overridden the methods (proc_image_file, get_image_file of rbpdf gem) to work better with the redmica_s3 plugin.
* Update the redmica_s3 plugin version number to 2.0.0 since Redmine 5.0.5 and above depend on version 1.21.0 of the rbpdf gem.

Ref: #23