### PR TITLE
Reflect Redmine-37530 changes (Timeout handling when generating a thumbnail)

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -7,6 +7,7 @@ curr_dirname = File.dirname(__FILE__)
 ).each do |require_file|
   require File.join(curr_dirname, 'lib', 'redmica_s3', require_file)
 end
+require File.join(curr_dirname, 'lib', 'mini_magick', 'shell')
 
 Redmine::Plugin.register :redmica_s3 do
   name 'RedMica S3 plugin'

--- a/init.rb
+++ b/init.rb
@@ -15,7 +15,7 @@ Redmine::Plugin.register :redmica_s3 do
   author 'Far End Technologies Corporation'
   author_url 'https://www.farend.co.jp'
 
-  version '2.0.0'
+  version '2.1.0'
   requires_redmine version_or_higher: '5.0.5'
 
   Redmine::Thumbnail.__send__(:include, RedmicaS3::ThumbnailPatch)

--- a/lib/mini_magick/shell.rb
+++ b/lib/mini_magick/shell.rb
@@ -1,0 +1,53 @@
+require "mini_magick"
+require "timeout"
+
+MiniMagick::Shell.prepend Module.new {
+  def run(command, options = {})
+    stdout, stderr, status = execute(command, stdin: options[:stdin], timeout: options[:timeout])
+
+    if status != 0 && options.fetch(:whiny, MiniMagick.whiny)
+      fail MiniMagick::Error, "`#{command.join(" ")}` failed with status: #{status.inspect} and error:\n#{stderr}"
+    end
+
+    $stderr.print(stderr) unless options[:stderr] == false || stderr.strip == %(WARNING: The convert command is deprecated in IMv7, use "magick")
+
+    [stdout, stderr, status]
+  end
+
+  private
+
+  def execute_open3(command, options = {})
+    require "open3"
+
+    # We would ideally use Open3.capture3, but it wouldn't allow us to
+    # terminate the command after timing out.
+    Open3.popen3(*command) do |in_w, out_r, err_r, thread|
+      [in_w, out_r, err_r].each(&:binmode)
+      stdout_reader = Thread.new { out_r.read }
+      stderr_reader = Thread.new { err_r.read }
+      begin
+        in_w.write options[:stdin].to_s
+      rescue Errno::EPIPE
+      end
+      in_w.close
+
+      timeout = options[:timeout] || MiniMagick.timeout
+      unless thread.join(timeout)
+        Process.kill("TERM", thread.pid) rescue nil
+        Process.waitpid(thread.pid)      rescue nil
+        raise Timeout::Error, "MiniMagick command timed out: #{command}"
+      end
+
+      [stdout_reader.value, stderr_reader.value, thread.value]
+    end
+  end
+
+  def execute_posix_spawn(command, options = {})
+    require "posix-spawn"
+    timeout = options[:timeout] || MiniMagick.timeout
+    child = POSIX::Spawn::Child.new(*command, input: options[:stdin].to_s, timeout: timeout)
+    [child.out, child.err, child.status]
+  rescue POSIX::Spawn::TimeoutExceeded
+    raise Timeout::Error, "MiniMagick command timed out: #{command}"
+  end
+}

--- a/lib/redmica_s3/thumbnail_patch.rb
+++ b/lib/redmica_s3/thumbnail_patch.rb
@@ -57,10 +57,9 @@ module RedmicaS3
                 convert << '-'
               end
               # Execute command
-              convert_output = nil
-              Timeout.timeout(Redmine::Configuration['thumbnails_generation_timeout'].to_i) do
-                convert_output = convert.call
-              end
+              timeout = Redmine::Configuration['thumbnails_generation_timeout'].to_i
+              timeout = nil if timeout <= 0
+              convert_output = convert.call(timeout: timeout)
               img = MiniMagick::Image.read(convert_output)
 
               img_blob = img.to_blob

--- a/lib/redmica_s3/thumbnail_patch.rb
+++ b/lib/redmica_s3/thumbnail_patch.rb
@@ -42,21 +42,19 @@ module RedmicaS3
             size_option = "#{size}x#{size}>"
             begin
               tempfile = MiniMagick::Utilities.tempfile(File.extname(source)) do |f| f.write(raw_data) end
-              convert_output =
-                if is_pdf
-                  MiniMagick::Tool::Convert.new do |cmd|
-                    cmd << "#{tempfile.to_path}[0]"
-                    cmd.thumbnail size_option
-                    cmd << 'png:-'
-                  end
-                else
-                  MiniMagick::Tool::Convert.new do |cmd|
-                    cmd << tempfile.to_path
-                    cmd.auto_orient
-                    cmd.thumbnail size_option
-                    cmd << '-'
-                  end
-                end
+              # Generate command
+              convert = MiniMagick::Tool::Convert.new
+              if is_pdf
+                convert << "#{tempfile.to_path}[0]"
+                convert.thumbnail size_option
+                convert << 'png:-'
+              else
+                convert << tempfile.to_path
+                convert.auto_orient
+                convert.thumbnail size_option
+                convert << '-'
+              end
+              convert_output = convert.call
               img = MiniMagick::Image.read(convert_output)
 
               img_blob = img.to_blob


### PR DESCRIPTION
https://www.redmine.org/issues/37530
Redmine [r22847](https://www.redmine.org/projects/redmine/repository/svn/revisions/22847) now has timeout handling when generating a thumbnail.

The redmica_s3 plugin has been improved by the above changes.
* Add timeout handling to the override method `Thumbnail.generate` of the redmica_s3 plugin.
* Update the redmica_s3 plugin version number to 2.1.0.
