### PR TITLE
Fix Aws::Errors::MissingRegionError: No region was provided

### DIFF
--- a/lib/redmica_s3/connection.rb
+++ b/lib/redmica_s3/connection.rb
@@ -101,11 +101,8 @@ module RedmicaS3
           access_key_id:      @@s3_options[:access_key_id],
           secret_access_key:  @@s3_options[:secret_access_key]
         }
-        if endpoint.present?
-          options[:endpoint] = endpoint
-        elsif region.present?
-          options[:region] = region
-        end
+        options[:endpoint] = endpoint
+        options[:region] = region
         @@conn = Aws::S3::Resource.new(options)
       end
 


### PR DESCRIPTION
The following settings are used against an [exoscale object storage](https://www.exoscale.com/object-storage/)
```
production:
  access_key_id: "EXO......."
  secret_access_key: "........"
  bucket: "some-service"
  folder: "seome_folder"
  endpoint: "https://sos-ch-dk-2.exo.io"
  thumb_folder: "thumb"
  import_folder: "import"
  region: 'ch-dk-2'
```
Without this patch, starting up fails with
```
rake aborted!
Aws::Errors::MissingRegionError: No region was provided. Configure the `:region` option or export the region name to ENV['AWS_REGION'] (Aws::Errors::MissingRegionError)

        raise Errors::MissingRegionError if region.nil? || region == ''
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/bundle/gems/aws-sdk-core-3.209.1/lib/aws-sdk-core/plugins/regional_endpoint.rb:84:in `after_initialize'
/usr/local/bundle/gems/aws-sdk-core-3.209.1/lib/seahorse/client/base.rb:81:in `block in after_initialize'
/usr/local/bundle/gems/aws-sdk-core-3.209.1/lib/seahorse/client/base.rb:80:in `each'
/usr/local/bundle/gems/aws-sdk-core-3.209.1/lib/seahorse/client/base.rb:80:in `after_initialize'
/usr/local/bundle/gems/aws-sdk-core-3.209.1/lib/seahorse/client/base.rb:23:in `initialize'
/usr/local/bundle/gems/aws-sdk-s3-1.167.0/lib/aws-sdk-s3/client.rb:552:in `initialize'
/usr/local/bundle/gems/aws-sdk-core-3.209.1/lib/seahorse/client/base.rb:102:in `new'
/usr/local/bundle/gems/aws-sdk-s3-1.167.0/lib/aws-sdk-s3/resource.rb:28:in `initialize'
/usr/src/redmine/plugins/redmica_s3/lib/redmica_s3/connection.rb:109:in `new'
/usr/src/redmine/plugins/redmica_s3/lib/redmica_s3/connection.rb:109:in `establish_connection'
/usr/src/redmine/plugins/redmica_s3/lib/redmica_s3/connection.rb:123:in `conn'
/usr/src/redmine/plugins/redmica_s3/lib/redmica_s3/connection.rb:127:in `own_bucket'
/usr/src/redmine/plugins/redmica_s3/lib/redmica_s3/connection.rb:21:in `create_bucket'
/usr/src/redmine/plugins/redmica_s3/init.rb:28:in `block in <top (required)>'
/usr/src/redmine/lib/redmine/plugin.rb:96:in `instance_eval'
/usr/src/redmine/lib/redmine/plugin.rb:96:in `register'
/usr/src/redmine/plugins/redmica_s3/init.rb:11:in `<top (required)>'
...
```
