### PR TITLE
Remove automatic bucket creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ This [Redmine](http://www.redmine.org) plugin makes file attachments be stored o
 6. Restart web server/upload to production/whatever
 7. *Optional*: Run `rake redmica_s3:files_to_s3` to upload files in your files folder to s3
 
-## Options Overview
-* The bucket specified in s3.yml will be created automatically when the plugin is loaded (this is generally when the server starts).
-
 ## Options Detail
 * access_key_id: string key (required)
 * secret_access_key: string key (required)

--- a/init.rb
+++ b/init.rb
@@ -24,6 +24,4 @@ Redmine::Plugin.register :redmica_s3 do
   Redmine::Export::PDF::ITCPDF.__send__(:include, RedmicaS3::PdfPatch)
   Import.__send__(:include, RedmicaS3::ImportPatch)
   AttachmentsController.__send__(:include, RedmicaS3::AttachmentsControllerPatch)
-
-  RedmicaS3::Connection.create_bucket
 end

--- a/lib/redmica_s3/connection.rb
+++ b/lib/redmica_s3/connection.rb
@@ -17,11 +17,6 @@ module RedmicaS3
     }
 
     class << self
-      def create_bucket
-        bucket = own_bucket
-        bucket.create unless bucket.exists?
-      end
-
       def folder
         str = @@s3_options[:folder]
         (


### PR DESCRIPTION
This pull reqeust removes automatic bucket creation from `init.rb`.

Currently, the bucket creation process runs not only during startup but also when executing commands like `bin/rails assets:precompile` or `bin/rails db:migrate`. If the connection settings in `s3.yml` are not properly configured, these commands fail. 

Generally, it is expected that the bucket is prepared in advance before using the plugin, so I believe it is unnecessary to handle bucket creation in `init.rb`.

This change has been tested with RedMica 3.1 to ensure compatibility.
