### PR TITLE
Run tests regularly to catch isses early

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - 'master'
       - 'dev*'
   pull_request:
+  schedule:
+    - cron: "0 23 * * 0-4"   # 08:00 JST, Monday to Friday
 
 jobs:
   test:


### PR DESCRIPTION
This plugin applies many patches to Redmine's core source code. As a result, changes in Redmine may break it. To detect and resolve such issues early, run tests regularly.