### PR TITLE
Temporarily pin LocalStack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
       - 'dev*'
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "0 23 * * 0-4"   # 08:00 JST, Monday to Friday
 

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -45,7 +45,7 @@ services:
       retries: 5
 
   s3:
-    image: localstack/localstack:s3-latest
+    image: localstack/localstack:4.14.0
     environment:
       SERVICES: s3
       DEBUG: ${DEBUG:-0}


### PR DESCRIPTION
Temporarily pin LocalStack to `4.14.0` in `docker/compose.yml` in response to the changes announced in https://blog.localstack.cloud/the-road-ahead-for-localstack/.

Confirmed this works locally.

Also added `workflow_dispatch` to the test workflow for manual runs.
