### PR TITLE
Use floci as the local S3 emulator

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -14,7 +14,7 @@ services:
     tty: true
     environment:
       AWS_REGION: ap-northeast-1
-      AWS_ENDPOINT_URL: https://s3.localhost.localstack.cloud:4566
+      AWS_ENDPOINT_URL: http://s3.localhost:4566
       CAPYBARA_SERVER_HOST: app
       CAPYBARA_SERVER_PORT: 8080
       SELENIUM_REMOTE_URL: http://selenium:4444/wd/hub
@@ -45,26 +45,25 @@ services:
       retries: 5
 
   s3:
-    image: localstack/localstack:4.14.0
+    image: hectorvent/floci:1.0.4
     environment:
-      SERVICES: s3
-      DEBUG: ${DEBUG:-0}
+      FLOCI_BASE_URL: http://s3.localhost:4566
+      FLOCI_STORAGE_MODE: memory
     ports:
       - '127.0.0.1:4566:4566'
-      - '127.0.0.1:4510-4559:4510-4559'
-    volumes:
-      - '/var/run/docker.sock:/var/run/docker.sock'
+    # Floci 1.0.4 runs as uid 1001, so make the tmpfs writable for that user.
+    tmpfs:
+      - /app/data:uid=1001,gid=0,mode=0775
     networks:
       default:
         aliases:
-          - 's3.localhost.localstack.cloud'
-          - 'redmine-bucket.s3.localhost.localstack.cloud'
+          - 's3.localhost'
+          - 'redmine-bucket.s3.localhost'
     healthcheck:
-      test: |
-        curl -s localhost:4566/_localstack/init/ready | grep '"completed": true'
+      test: curl -fsS --connect-timeout 1 http://localhost:4566/
       interval: 5s
-      timeout: 5s
-      start_period: 1m
+      timeout: 2s
+      start_period: 5s
       retries: 5
 
   selenium:

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,7 +46,6 @@ class ApplicationSystemTestCase
     @s3_client ||= Aws::S3::Client.new(
       endpoint: ENV['AWS_ENDPOINT_URL'],
       region: ENV['AWS_REGION'],
-      force_path_style: true,
       access_key_id: 'test',
       secret_access_key: 'test'
     )


### PR DESCRIPTION
Switch from LocalStack to [floci](https://github.com/hectorvent/floci) for local S3 emulation in development and testing. Confirmed works well locally.

- floci stores files under `/app/data/s3`
- The documentation does not explicitly mention support for virtual-hosted-style requests, but floci has [an implementation for it](https://github.com/hectorvent/floci/blob/main/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java) and it works in practice
