### PR TITLE
Remove overridden `Redmine::Thumbnail.generate` method

### DIFF
--- a/lib/redmica_s3/attachment_patch.rb
+++ b/lib/redmica_s3/attachment_patch.rb
@@ -150,17 +150,47 @@ module RedmicaS3
         size = 100 unless size > 0
         target = thumbnail_path(size)
 
-        diskfile_s3  = diskfile
+        target_folder = RedmicaS3::Connection.thumb_folder
+        target_obj = RedmicaS3::Connection.object(target, target_folder)
+        if target_obj.exists?
+          return [target_obj.metadata['digest'], target_obj.get.body.read]
+        end
+
+        source_extname = File.extname(diskfile)
+        source_temp = Tempfile.new([File.basename(diskfile, source_extname), source_extname], binmode: true)
+        source_temp.write(raw_data)
+        source_temp.flush
+        target_extname = File.extname(target)
+        target_temp = Tempfile.new([File.basename(target, target_extname), target_extname])
+        target_temp_path = target_temp.path
+        target_temp.close!
+
         begin
           # TODO: Stop passing the deprecated is_pdf flag in Redmine 7.0
-          Redmine::Thumbnail.generate(diskfile_s3, target, size, is_pdf?)
-        rescue => e
-          Rails.logger.error(
-            "An error occured while generating thumbnail for #{diskfile_s3} " \
-              "to #{target}\nException was: #{e.message}"
-          )
-          nil
+          if Redmine::Thumbnail.generate(source_temp.path, target_temp_path, size, is_pdf?)
+            thumbnail_blob = File.binread(target_temp_path)
+            mime_type = Marcel::MimeType.for(thumbnail_blob)
+            digest = Digest::SHA256.hexdigest(thumbnail_blob)
+            RedmicaS3::Connection.put(
+              target,
+              File.basename(target),
+              thumbnail_blob,
+              mime_type,
+              target_folder: target_folder,
+              digest: digest
+            )
+            [digest, thumbnail_blob]
+          end
+        ensure
+          source_temp.close!
+          File.delete(target_temp_path) if File.exist?(target_temp_path)
         end
+      rescue => e
+        Rails.logger.error(
+          "An error occured while generating thumbnail for #{diskfile} " \
+            "to #{target}\nException was: #{e.message}"
+        )
+        nil
       end
 
       # Returns true if the file is readable

--- a/lib/redmica_s3/thumbnail_patch.rb
+++ b/lib/redmica_s3/thumbnail_patch.rb
@@ -1,5 +1,3 @@
-require 'timeout'
-
 module RedmicaS3
   module ThumbnailPatch
     extend ActiveSupport::Concern
@@ -26,85 +24,6 @@ module RedmicaS3
       end
 
       module ClassMethods
-        # Generates a thumbnail for the source image to target
-        # TODO: Remove the deprecated _is_pdf parameter in Redmine 7.0
-        def generate(source, target, size, _is_pdf = nil)
-          return nil unless convert_available?
-
-          target_folder = RedmicaS3::Connection.thumb_folder
-          object = RedmicaS3::Connection.object(target, target_folder)
-          unless object.exists?
-            return nil unless Object.const_defined?(:MiniMagick)
-
-            raw_data = RedmicaS3::Connection.object(source).reload.get.body.read rescue nil
-            mime_type = Marcel::MimeType.for(raw_data)
-            return nil unless Redmine::Thumbnail::ALLOWED_TYPES.include? mime_type
-
-            size_option = "#{size}x#{size}>"
-            begin
-              extname_source = File.extname(source)
-              tempfile = MiniMagick::Utilities.tempfile(extname_source) do |f| f.write(raw_data) end
-              in_filepath = tempfile.path
-              if mime_type == 'application/pdf'
-                return nil unless gs_available?
-                return nil unless valid_pdf_magic?(in_filepath)
-              end
-              output_tempfile = MiniMagick::Utilities.tempfile(mime_type == 'application/pdf' ? ".png" : extname_source)
-              out_filepath = output_tempfile.path
-              # Generate command
-              convert =
-                if MiniMagick.version < Gem::Version.new('5.0.0')
-                  MiniMagick::Tool::Convert.new # MiniMagick::Tool::Convert is deprecated in MiniMagick 5.0.0
-                else
-                  MiniMagick.convert
-                end
-              if mime_type == 'application/pdf'
-                convert << "#{in_filepath}[0]"
-                convert.thumbnail size_option
-                convert << "png:#{out_filepath}"
-              else
-                convert << in_filepath
-                convert.auto_orient
-                convert.thumbnail size_option
-                convert << out_filepath
-              end
-              # Execute command (Note: Timeout control reuses code from Redmine itself)
-              timeout = Redmine::Configuration['thumbnails_generation_timeout'].to_i
-              timeout = nil if timeout <= 0
-              pid = nil
-              cmd = convert.command
-              Timeout.timeout(timeout) do
-                pid = Process.spawn(*cmd)
-                _, status = Process.wait2(pid)
-                unless status.success?
-                  Rails.logger.error("Creating thumbnail failed (#{status.exitstatus}):\nCommand: #{cmd.join(' ')}")
-                  return nil
-                end
-              end
-              img_blob = File.binread(out_filepath)
-              mime_type = Marcel::MimeType.for(img_blob)
-              sha = Digest::SHA256.new
-              sha.update(img_blob)
-              new_digest = sha.hexdigest
-              RedmicaS3::Connection.put(target, File.basename(target), img_blob, mime_type,
-                {target_folder: target_folder, digest: new_digest}
-              )
-            rescue Timeout::Error
-              Process.kill('KILL', pid) if pid
-              Rails.logger.error("Creating thumbnail timed out:\nCommand: #{cmd.join(' ')}")
-              return nil
-            rescue => e
-              Rails.logger.error("Creating thumbnail failed (#{e.message}):")
-              return nil
-            ensure
-              tempfile.unlink if tempfile
-              output_tempfile.unlink if output_tempfile
-            end
-          end
-
-          object.reload
-          [object.metadata['digest'], object.get.body.read]
-        end
       end
     end
   end


### PR DESCRIPTION
## Summary

- stop relying on the plugin-side override of `Redmine::Thumbnail.generate`

## Details

This change moves the S3-specific thumbnail handling into the attachment thumbnail flow (`Attachment#thumbnail`) instead of overriding `Redmine::Thumbnail.generate`.

When a thumbnail is requested:

- the code first checks whether the thumbnail already exists in the S3 thumbnail bucket
- if it exists, it returns the stored digest and binary data immediately
- if it does not exist, it writes the source attachment data to a temporary file
- it then calls Redmine's thumbnail generator with local temp paths
- when generation succeeds, the thumbnail is uploaded to S3 together with its digest metadata

The change ensures proper cleanup of temporary files and retains error logs in case thumbnail generation fails.