### PR TITLE
Align markdownized preview cache path with Redmine core

### DIFF
--- a/lib/redmica_s3/connection.rb
+++ b/lib/redmica_s3/connection.rb
@@ -42,7 +42,7 @@ module RedmicaS3
       end
 
       def markdownized_previews_folder
-        "#{folder}markdownized_previews/"
+        "#{folder}derived_cache/markdownized_previews/"
       end
 
       def put(disk_filename, original_filename, data, content_type = 'application/octet-stream', opt = {})

--- a/test/system/issue_attachment_system_test.rb
+++ b/test/system/issue_attachment_system_test.rb
@@ -136,6 +136,8 @@ module RedmicaS3
       end
 
       assert_selector '.filecontent.wiki', text: /This is a docx file\./
+      assert_equal 1, count_s3_markdownized_preview_objects
+      assert verify_markdownized_preview_stored_in_s3(attachment)
     end
 
     test 'should preview odt file on attachment display page' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,6 +22,13 @@ class ApplicationSystemTestCase
     verify_file_stored_in_s3(attachment.diskfile, 'attachments')
   end
 
+  def verify_markdownized_preview_stored_in_s3(attachment)
+    verify_file_stored_in_s3(
+      attachment.send(:markdownized_preview_cache_path),
+      RedmicaS3::Connection.markdownized_previews_folder
+    )
+  end
+
   def verify_file_stored_in_s3(filename, folder)
     key = File.join(folder, filename)
     s3_client.head_object(bucket: 'redmine-bucket', key: key)
@@ -30,11 +37,15 @@ class ApplicationSystemTestCase
   end
 
   def count_s3_attachment_objects
-    count_s3_objects - count_s3_thumbnail_objects
+    count_s3_objects - count_s3_thumbnail_objects - count_s3_markdownized_preview_objects
   end
 
   def count_s3_thumbnail_objects
     count_s3_objects(prefix: 'attachments/thumbnails')
+  end
+
+  def count_s3_markdownized_preview_objects
+    count_s3_objects(prefix: RedmicaS3::Connection.markdownized_previews_folder)
   end
 
   def count_s3_objects(prefix: nil)


### PR DESCRIPTION
## Background

Redmine core changed the markdownized preview cache path from `files/markdownized_previews/` to `files/derived_cache/markdownized_previews/`.
https://github.com/redmine/redmine/commit/ca55004521f06a4cf87e421e228de3d1f6add9d7

This patch aligns redmica_s3 with that storage layout so S3-backed preview caching follows the same directory structure.

## Detail

- store markdownized preview cache under `derived_cache/markdownized_previews/` on S3
- add an assertion to verify that the generated markdownized preview is stored in the new S3 prefix
  - the assertion is added to the `docx` test only, because one case is enough to cover the shared cache path logic.

## Testing

- confirmed the behavior locally

```
bash-5.1$ ls /app/data/s3/redmine-bucket/attachments/derived_cache/
markdownized_previews
```
```
bash-5.1$ ls /app/data/s3/redmine-bucket/attachments/derived_cache/markdownized_previews/
3128b606824f2e3fc145670e9092caafda74bfc5373828583f5aa6ef3e7cc456_4720.md
```