### PR TITLE
mention where S3 files are stored in development README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ docker compose exec app bin/rails s -e production
 
 Visit http://localhost:3000 to access Redmine.
 
+> [!Note]
+> In the Docker development environment, [floci](https://github.com/floci-io/floci) is used as the S3 emulator.
+> S3 files are stored under `/app/data/s3` in the `s3` container.
+
 ### Running Tests
 
 ```


### PR DESCRIPTION
- mention that the Docker development environment uses [floci](https://github.com/floci-io/floci) as the S3 emulator
- document that S3 files are stored under `/app/data/s3` in the `s3` container
