### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         redmica_version:
           - 'master'
+          - 'stable-4.1'
 
     steps:
     - name: Checkout plugin

--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@
 [![Test](https://github.com/redmica/redmica_s3/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/redmica/redmica_s3/actions/workflows/test.yml)
 
 ## Description
-This [Redmine](http://www.redmine.org) plugin makes file attachments be stored on [Amazon S3](http://aws.amazon.com/s3) rather than on the local filesystem. This is a fork for [original gem](http://github.com/tigrish/redmine_s3) and difference is that this one supports [RedMica](https://github.com/redmica/redmica) 4.0.2 or later(compatible with Redmine 6.1.1 or later)
+This [Redmine](http://www.redmine.org) plugin makes file attachments be stored on [Amazon S3](http://aws.amazon.com/s3) rather than on the local filesystem.
+
+## Supported Versions
+
+| Version | RedMica | Redmine |
+| ------- | ------- | ------- |
+| v4.0.0 or later | v4.1 or later | trunk |
+| v3.2.0 | v4.0 | v6.1 |
 
 ## Installation
 

--- a/init.rb
+++ b/init.rb
@@ -16,7 +16,7 @@ Redmine::Plugin.register :redmica_s3 do
   author 'Far End Technologies Corporation'
   author_url 'https://www.farend.co.jp'
 
-  version '3.1.0'
+  version '4.0.0'
   requires_redmine version_or_higher: '6.1.1'
 
   Redmine::Markdownizer.__send__(:include, RedmicaS3::MarkdownizerPatch)


### PR DESCRIPTION
This PR bumps the version to v4.0.0. Since v4.0.0 includes support for changes such as https://www.redmine.org/issues/8959, it requires RedMica v4.1 or later. Redmine support is currently limited to trunk.

This PR also makes the following related changes:

* Adds a supported versions table to make it easier to describe the supported RedMica and Redmine versions

It also adds `stable-4.1` to the test matrix.