### PR TITLE
Fix attachment previews for SVG and PDF

### DIFF
--- a/lib/redmica_s3/attachments_controller_patch.rb
+++ b/lib/redmica_s3/attachments_controller_patch.rb
@@ -32,13 +32,13 @@ module RedmicaS3
                 User.current.preference.save
               end
               render action: 'diff'
-            elsif @attachment.is_text? && @attachment.filesize <= Setting.file_max_size_displayed.to_i.kilobyte
-              @content = @attachment.raw_data
-              render action: 'file'
             elsif @attachment.is_image?
               render action: 'image'
             elsif @attachment.is_pdf?
               render action: 'pdf'
+            elsif @attachment.is_text? && @attachment.filesize <= Setting.file_max_size_displayed.to_i.kilobyte
+              @content = @attachment.raw_data
+              render action: 'file'
             elsif @content = @attachment.markdownized_preview_content
               render action: 'markdownized'
             else

--- a/test/fixtures/files/svg.svg
+++ b/test/fixtures/files/svg.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="80" viewBox="0 0 120 80">
+  <rect width="120" height="80" fill="#ffffff"/>
+  <circle cx="40" cy="40" r="24" fill="#cc2936"/>
+  <path d="M68 24h28v32H68z" fill="#0b7285"/>
+</svg>

--- a/test/system/issue_attachment_system_test.rb
+++ b/test/system/issue_attachment_system_test.rb
@@ -123,6 +123,15 @@ module RedmicaS3
       end
     end
 
+    test 'should preview svg file as image' do
+      attachment = create_issue_with_attachments('svg.svg').attachments.first
+
+      visit attachment_path(attachment)
+
+      path = download_named_attachment_path(attachment, attachment.filename)
+      assert_selector "img.filecontent[src='#{path}'][alt='svg.svg']"
+    end
+
     test 'should preview docx file on attachment display page' do
       issue = create_issue_with_attachments('docx.docx')
       attachment = issue.attachments.first

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,6 +69,7 @@ class ApplicationSystemTestCase
       when '.txt' then 'text/plain'
       when '.png' then 'image/png'
       when '.pdf' then 'application/pdf'
+      when '.svg' then 'image/svg+xml'
       else 'application/octet-stream'
       end
 


### PR DESCRIPTION
This PR addresses:

- Support previewing SVG attachments as images for https://www.redmine.org/issues/44126.
- Fix PDF previews broken by Rouge 5 treating PDF files as text.

Confirmed that the changes work as expected:

<img width="1262" height="489" alt="CleanShot 2026-06-08 at 11 48 09" src="https://github.com/user-attachments/assets/1a285a32-3174-4f79-a987-31f5c3b0e7b2" />

<img width="1261" height="489" alt="CleanShot 2026-06-08 at 11 48 03" src="https://github.com/user-attachments/assets/d0dcf0d6-53d8-40b9-8d9a-a72808863278" />
