### PR TITLE
Prepare test database in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,10 @@ jobs:
       run: docker compose up -d --wait
       working-directory: docker
 
+    - name: Prepare test database
+      run: docker compose exec app bin/rails db:test:prepare
+      working-directory: docker
+
     - name: Run tests
       run: docker compose exec app bin/rails redmine:plugins:test NAME=redmica_s3
       working-directory: docker


### PR DESCRIPTION
## Summary

- Prepare the test database before running plugin tests in CI

## Why

The CI job failed once with pending migrations in the test database. The exact trigger is not clear, but `redmine:plugins:test` itself does not depend on `db:test:prepare`, so the workflow currently relies on implicit test database preparation.

This makes the CI setup fragile. Preparing the test database explicitly before running plugin tests makes the workflow deterministic.
