### PR TITLE
Fix app healthcheck passing before migrations complete

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -24,7 +24,7 @@ services:
       - ../tmp/screenshots:/redmica/tmp/screenshots
       - bundle_cache:/usr/local/bundle
     healthcheck:
-      # The entrypoint creates tmp/.ready once setup (bundle install and db:migrate) is complete.
+      # The entrypoint creates tmp/.ready once its setup steps are complete.
       test: test -f tmp/.ready
       interval: 10s
       start_period: 5m

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -24,11 +24,11 @@ services:
       - ../tmp/screenshots:/redmica/tmp/screenshots
       - bundle_cache:/usr/local/bundle
     healthcheck:
-      test: bin/rails db:migrate:status
+      # The entrypoint creates tmp/.ready once setup (bundle install and db:migrate) is complete.
+      test: test -f tmp/.ready
       interval: 10s
-      timeout: 5s
-      start_period: 1m
-      retries: 10
+      start_period: 5m
+      retries: 5
 
   db:
     image: postgres:14

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,6 +3,8 @@ set -e
 
 cd /redmica
 
+rm -f tmp/.ready
+
 cat > config/database.yml << EOF
 default: &default
   adapter: postgresql
@@ -47,5 +49,7 @@ bin/rails generate_secret_token
 bin/rails db:create db:migrate
 
 bin/rails r "RedmicaS3::Connection.send(:own_bucket).tap { |bucket| bucket.create unless bucket.exists? }"
+
+touch tmp/.ready
 
 exec "$@"


### PR DESCRIPTION
The healthcheck used `bin/rails db:migrate:status`, which exits 0 as soon as the schema_migrations table exists, even while migrations are still running. This let CI start the test step mid-setup and fail with `ActiveRecord::PendingMigrationError`.
https://github.com/redmica/redmica_s3/actions/runs/29059022496/attempts/1

Have the entrypoint create tmp/.ready after setup finishes and check for that file instead, so healthy reliably means bundle install and `db:migrate` are done.