### PR TITLE
Adapt to Redmine #43484 content type detection changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         redmica_version:
           - 'master'
-          - 'stable-4.1'
 
     steps:
     - name: Checkout plugin

--- a/lib/redmica_s3/attachment_patch.rb
+++ b/lib/redmica_s3/attachment_patch.rb
@@ -89,6 +89,12 @@ module RedmicaS3
 
       end
 
+      def reset_content_type
+        return unless readable?
+
+        self.content_type = Marcel::MimeType.for(s3_object.get.body, name: filename)
+      end
+
       # Copies the temporary file to its final location
       # and computes its hash
       def files_to_final_location

--- a/lib/redmica_s3/attachment_patch.rb
+++ b/lib/redmica_s3/attachment_patch.rb
@@ -98,43 +98,34 @@ module RedmicaS3
       # Copies the temporary file to its final location
       # and computes its hash
       def files_to_final_location
-        if @temp_file
-          self.disk_directory = target_directory
-          self.disk_filename = Attachment.disk_filename(filename, disk_directory)
-          Rails.logger.info("Saving attachment '#{self.diskfile}' (#{@temp_file.size} bytes)")
-          sha = Digest::SHA256.new
-          if @temp_file.respond_to?(:read)
-            buffer = ""
-            while (buffer = @temp_file.read(8192))
-              sha.update(buffer)
-            end
-          else
-            sha.update(@temp_file)
+        return unless @temp_file
+
+        self.disk_directory = target_directory
+        self.disk_filename = Attachment.disk_filename(filename, disk_directory)
+        Rails.logger.info("Saving attachment '#{self.diskfile}' (#{@temp_file.size} bytes)")
+
+        sha = Digest::SHA256.new
+        if @temp_file.respond_to?(:read)
+          buffer = ""
+          while (buffer = @temp_file.read(8192))
+            sha.update(buffer)
           end
-
-          self.digest = sha.hexdigest
-        end
-        if content_type.blank? && filename.present?
-          self.content_type = Redmine::MimeType.of(filename)
-        end
-        # Don't save the content type if it's longer than the authorized length
-        if self.content_type && self.content_type.length > 255
-          self.content_type = nil
+        else
+          sha.update(@temp_file)
         end
 
-        if @temp_file
-          raw_data =
-            if @temp_file.respond_to?(:read)
-              @temp_file.rewind
-              @temp_file.read
-            else
-              @temp_file
-            end
-          RedmicaS3::Connection.put(self.diskfile, self.filename, raw_data,
-             (self.content_type || 'application/octet-stream'),
-             {digest: self.digest}
-          )
-        end
+        self.digest = sha.hexdigest
+        raw_data =
+          if @temp_file.respond_to?(:read)
+            @temp_file.rewind
+            @temp_file.read
+          else
+            @temp_file
+          end
+        RedmicaS3::Connection.put(self.diskfile, self.filename, raw_data,
+           (self.content_type || 'application/octet-stream'),
+           {digest: self.digest}
+        )
       ensure
         @temp_file = nil
       end

--- a/test/fixtures/files/test.bin
+++ b/test/fixtures/files/test.bin
@@ -1,0 +1,1 @@
+This is a text attachment.

--- a/test/system/issue_attachment_system_test.rb
+++ b/test/system/issue_attachment_system_test.rb
@@ -86,6 +86,32 @@ module RedmicaS3
       assert verify_attachment_stored_in_s3(added_attachment)
     end
 
+    test 'rename attachment and reset content type' do
+      issue = create_issue_with_attachments('test.bin')
+      attachment = issue.attachments.first
+
+      assert_equal 'application/octet-stream', attachment.content_type
+
+      visit "/issues/#{issue.id}"
+
+      within '.attachments' do
+        click_link 'Edit attached files'
+      end
+
+      within "#attachment-#{attachment.id}" do
+        find("#attachments_#{attachment.id}_filename").set('test.txt')
+      end
+      click_button 'Save'
+      assert_current_path "/issues/#{issue.id}"
+
+      attachment.reload
+      assert_equal 'test.txt', attachment.filename
+      assert_equal 'text/plain', attachment.content_type
+
+      visit attachment_path(attachment)
+      assert_text file_fixture('test.bin').read
+    end
+
     test 'remove attachments' do
       issue = create_issue_with_attachments('text.txt')
 


### PR DESCRIPTION
Support [Redmine #43484](https://www.redmine.org/issues/43484).

- Override `reset_content_type` to re-detect an attachment’s MIME type from its S3 object when the filename changes.
- Remove the legacy MIME type fallback from `files_to_final_location` to align with current Redmine core behavior.
- Add a system test for attachment filename changes.
- Remove `stable-4.1` branch from test targets due to incompatible changes.

Tests:

- The test suite passes.
- Normal attachment uploads continue to work as before.
- The S3 object `Content-Type` matches the detected `Attachment#content_type`.
- Renaming an attachment works well.
- Attachments can be downloaded and displayed after a filename change.
- PDF inline/attachment handling continues to use Redmine core’s updated `disposition` behavior without changes to `AttachmentsControllerPatch`.
