### PR TITLE
Adapt to Redmine #41434 CSV import fails on CRLF files when first row has quoted field with newline

### DIFF
--- a/lib/redmica_s3/import_patch.rb
+++ b/lib/redmica_s3/import_patch.rb
@@ -57,6 +57,8 @@ module RedmicaS3
         csv_options = {:headers => false}
         separator = settings['separator'].to_s
         csv_options[:col_sep] = separator if separator.size == 1
+        newline = settings['newline'].to_s
+        csv_options[:row_sep] = newline unless newline.empty?
         wrapper = settings['wrapper'].to_s
         csv_options[:quote_char] = wrapper if wrapper.size == 1
 

--- a/test/fixtures/files/issue_import_crlf_with_newline_in_quoted_header.csv
+++ b/test/fixtures/files/issue_import_crlf_with_newline_in_quoted_header.csv
@@ -1,0 +1,3 @@
+plain_header,"quoted_header
+contains_LF",Tracker,Subject
+foo,bar,Bug,"CSV with CRLF and newline in quoted header"

--- a/test/system/issue_import_system_test.rb
+++ b/test/system/issue_import_system_test.rb
@@ -10,10 +10,12 @@ module RedmicaS3
 
       attach_file 'file', file_fixture('issue_import.csv')
       click_button 'Next »'
-      assert_equal 1, count_s3_objects
 
       # Import options page
-      assert_selector '#import-form legend', text: 'Options'
+      find('#import-form legend', text: 'Options') do
+        assert_equal 1, count_s3_objects
+      end
+
       click_button 'Next »'
 
       # Import fields mapping page

--- a/test/system/issue_import_system_test.rb
+++ b/test/system/issue_import_system_test.rb
@@ -2,12 +2,14 @@ require_relative '../test_helper'
 
 module RedmicaS3
   class IssueImportSystemTest < ApplicationSystemTestCase
-    test 'issue import from csv creates issues with multibyte subjects' do
+    setup do
       log_user 'admin', 'admin'
 
       visit '/issues/imports/new?project_id=ecookbook'
       assert_text 'Import issues'
+    end
 
+    test 'issue import from csv creates issues with multibyte subjects' do
       attach_file 'file', file_fixture('issue_import.csv')
       click_button 'Next »'
 
@@ -36,6 +38,44 @@ module RedmicaS3
       # verify imported issue attributes
       imported_issue = Issue.order(:id).last
       assert_equal 'English日本語Mix', imported_issue.subject
+      assert_equal 'Bug', imported_issue.tracker.name
+      assert_equal 0, count_s3_objects
+    end
+
+    test 'issue import from csv with crlf and newline in quoted header' do
+      attach_file 'file', file_fixture('issue_import_crlf_with_newline_in_quoted_header.csv')
+      click_button 'Next »'
+
+      # Import options page
+      find('#import-form legend', text: 'Options') do
+        assert_equal 1, count_s3_objects
+      end
+
+      within '#import-form' do
+        select 'Comma', from: 'Field separator'
+        select 'Double quote', from: 'Field wrapper'
+        select 'UTF-8', from: 'Encoding'
+      end
+      click_button 'Next »'
+
+      # Import fields mapping page
+      assert_selector '#import-form legend', text: 'Fields mapping'
+      within '.sample-data' do
+        assert_text 'Bug'
+        assert_text 'CSV with CRLF and newline in quoted header'
+      end
+
+      click_button 'Import'
+
+      # Import result page
+      within '#saved-items' do
+        assert_text 'Bug #'
+        assert_text 'CSV with CRLF and newline in quoted header'
+      end
+
+      # verify imported issue attributes
+      imported_issue = Issue.order(:id).last
+      assert_equal 'CSV with CRLF and newline in quoted header', imported_issue.subject
       assert_equal 'Bug', imported_issue.tracker.name
       assert_equal 0, count_s3_objects
     end


### PR DESCRIPTION
## Purpose
When importing issues from a CSV file stored on S3, `read_rows` built the `CSV.parse` options from the `separator` and `wrapper` import settings but ignored the `newline` setting. As a result, CSV files using a row separator other than the CSV gem's default (e.g. CRLF, or files with LF inside a quoted field) could be parsed incorrectly.

## Changes
- `lib/redmica_s3/import_patch.rb` — pass the `newline` import setting through to `CSV.parse` as `:row_sep`, mirroring how `separator` and `wrapper` are already handled.
- Added a fixture file (`issue_import_crlf_with_newline_in_quoted_header.csv`) and a new system test covering CSV import with CRLF row separators and a newline embedded inside a quoted header.
- Refactored the existing system test's shared setup (login + navigating to the import page) into a `setup` block, and scoped the `count_s3_objects` assertion inside the `#import-form` legend check, to fix a race condition and support the new test case.

## Verification
- [ ] Run `test/system/issue_import_system_test.rb` and confirm both the existing multibyte-subject test and the new CRLF/newline test pass.

## References
- https://www.redmine.org/issues/41434
- https://github.com/redmine/redmine/commit/47e3c27e937810677a679e2401c089761d040ee5#diff-51189a09018837b92ad54e3bc7988b6a1ab27790b0e6c55304ebeac193ce3634R277-R278

---
Supersedes #68, which was auto-closed when the `issue-88540` branch was renamed to `csv-import-newline-setting`.