### PR TITLE
Move CRLF import test to functional test

### DIFF
--- a/test/functional/imports_controller_test.rb
+++ b/test/functional/imports_controller_test.rb
@@ -9,10 +9,6 @@ module RedmicaS3
       @request.session[:user_id] = 2
     end
 
-    def teardown
-      Import.destroy_all
-    end
-
     test 'issue import from csv with crlf and newline in quoted header' do
       import = new_record(Import) do
         post :create, params: {

--- a/test/functional/imports_controller_test.rb
+++ b/test/functional/imports_controller_test.rb
@@ -1,0 +1,60 @@
+require_relative '../test_helper'
+
+module RedmicaS3
+  class ImportsControllerTest < Redmine::ControllerTest
+    tests ::ImportsController
+
+    def setup
+      User.current = nil
+      @request.session[:user_id] = 2
+    end
+
+    def teardown
+      Import.destroy_all
+    end
+
+    test 'issue import from csv with crlf and newline in quoted header' do
+      import = new_record(Import) do
+        post :create, params: {
+          type: 'IssueImport',
+          file: uploaded_test_file('issue_import_crlf_with_newline_in_quoted_header.csv', 'text/csv')
+        }
+        assert_response :found
+      end
+      assert_equal "\r\n", import.settings['newline']
+
+      post :settings, params: {
+        id: import.to_param,
+        import_settings: {
+          separator: ',',
+          wrapper: '"',
+          encoding: 'UTF-8'
+        }
+      }
+      assert_response :found
+      import.reload
+      assert_equal 1, import.total_items
+
+      post :mapping, params: {
+        id: import.to_param,
+        import_settings: {
+          mapping: {
+            project_id: '1',
+            tracker: '2',
+            subject: '3'
+          }
+        }
+      }
+      assert_response :found
+
+      assert_difference 'Issue.count', 1 do
+        post :run, params: { id: import.to_param }
+        assert_response :found
+      end
+
+      import.reload
+      issue = Issue.find(import.items.first.obj_id)
+      assert_equal 'CSV with CRLF and newline in quoted header', issue.subject
+    end
+  end
+end

--- a/test/system/issue_import_system_test.rb
+++ b/test/system/issue_import_system_test.rb
@@ -41,43 +41,5 @@ module RedmicaS3
       assert_equal 'Bug', imported_issue.tracker.name
       assert_equal 0, count_s3_objects
     end
-
-    test 'issue import from csv with crlf and newline in quoted header' do
-      attach_file 'file', file_fixture('issue_import_crlf_with_newline_in_quoted_header.csv')
-      click_button 'Next »'
-
-      # Import options page
-      find('#import-form legend', text: 'Options') do
-        assert_equal 1, count_s3_objects
-      end
-
-      within '#import-form' do
-        select 'Comma', from: 'Field separator'
-        select 'Double quote', from: 'Field wrapper'
-        select 'UTF-8', from: 'Encoding'
-      end
-      click_button 'Next »'
-
-      # Import fields mapping page
-      assert_selector '#import-form legend', text: 'Fields mapping'
-      within '.sample-data' do
-        assert_text 'Bug'
-        assert_text 'CSV with CRLF and newline in quoted header'
-      end
-
-      click_button 'Import'
-
-      # Import result page
-      within '#saved-items' do
-        assert_text 'Bug #'
-        assert_text 'CSV with CRLF and newline in quoted header'
-      end
-
-      # verify imported issue attributes
-      imported_issue = Issue.order(:id).last
-      assert_equal 'CSV with CRLF and newline in quoted header', imported_issue.subject
-      assert_equal 'Bug', imported_issue.tracker.name
-      assert_equal 0, count_s3_objects
-    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,10 +2,9 @@ require_relative '../../../test/test_helper'
 require_relative '../../../test/application_system_test_case'
 require 'rack/test'
 
-ActiveSupport::TestCase.file_fixture_path =
-  File.join(Redmine::Plugin.find('redmica_s3').directory, 'test', 'fixtures', 'files')
-
 class ActiveSupport::TestCase
+  self.file_fixture_path = File.join(Redmine::Plugin.find('redmica_s3').directory, 'test', 'fixtures', 'files')
+
   setup do
     cleanup_s3_bucket
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require 'rack/test'
 ActiveSupport::TestCase.file_fixture_path =
   File.join(Redmine::Plugin.find('redmica_s3').directory, 'test', 'fixtures', 'files')
 
-class ApplicationSystemTestCase
+class ActiveSupport::TestCase
   setup do
     cleanup_s3_bucket
   end
@@ -18,7 +18,9 @@ class ApplicationSystemTestCase
   rescue => e
     Rails.logger.error "Error cleaning up S3 bucket: #{e.message}"
   end
+end
 
+class ApplicationSystemTestCase
   def verify_attachment_stored_in_s3(attachment)
     verify_file_stored_in_s3(attachment.diskfile, 'attachments')
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,9 +2,10 @@ require_relative '../../../test/test_helper'
 require_relative '../../../test/application_system_test_case'
 require 'rack/test'
 
-class ApplicationSystemTestCase
-  self.file_fixture_path = File.join(Redmine::Plugin.find('redmica_s3').directory, 'test', 'fixtures', 'files')
+ActiveSupport::TestCase.file_fixture_path =
+  File.join(Redmine::Plugin.find('redmica_s3').directory, 'test', 'fixtures', 'files')
 
+class ApplicationSystemTestCase
   setup do
     cleanup_s3_bucket
   end


### PR DESCRIPTION
The system test added in #63 seems a little too heavy for testing the import of a CRLF file. This test only needs to verify that the file can be imported correctly; it does not need to test the UI flow of the import process.

I think system tests for this plugin only need to cover one or two key user flows involving the plugin, as a replacement for manual end-to-end testing. The existing system tests already cover the import flow.

For these reasons, I think the CRLF-specific case is better covered by a functional test.