### PR TITLE
Adapt to Redmine #44362 Preview PDF compatible Adobe Illustrator files

### DIFF
--- a/lib/redmica_s3/attachments_controller_patch.rb
+++ b/lib/redmica_s3/attachments_controller_patch.rb
@@ -34,7 +34,7 @@ module RedmicaS3
               render action: 'diff'
             elsif @attachment.is_image?
               render action: 'image'
-            elsif @attachment.is_pdf?
+            elsif @attachment.pdf_previewable?
               render action: 'pdf'
             elsif @attachment.is_text? && @attachment.filesize <= Setting.file_max_size_displayed.to_i.kilobyte
               @content = @attachment.raw_data

--- a/test/functional/attachments_controller_test.rb
+++ b/test/functional/attachments_controller_test.rb
@@ -1,0 +1,28 @@
+require_relative '../test_helper'
+
+module RedmicaS3
+  class AttachmentsControllerTest < Redmine::ControllerTest
+    tests ::AttachmentsController
+
+    setup do
+      User.current = nil
+      @request.session[:user_id] = 2
+    end
+
+    test 'show pdf compatible illustrator file should be previewed' do
+      attachment = Attachment.create!(
+        file: mock_file_with_options(
+          original_filename: 'test.ai',
+          content: file_fixture('pdf.pdf').binread
+        ),
+        author_id: 2,
+        container: Issue.find(1)
+      )
+      assert_equal 'application/illustrator', attachment.content_type
+
+      get(:show, params: {id: attachment.id})
+      assert_response :success
+      assert_select 'div.filecontent.pdf object[type=?]', 'application/pdf'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fixes an issue where Adobe Illustrator files saved in the PDF compatible format (`.ai`, content_type: `application/illustrator`) were not previewed on the attachment view page.

## Cause
`AttachmentsController#show` used `Attachment#is_pdf?`, which only checks whether the content_type is `application/pdf`, so PDF-compatible Illustrator files were not rendered as a PDF preview.

## Fix
Replaced `Attachment#is_pdf?` with `Attachment#pdf_previewable?`, which Redmine core documents as also covering PDF-compatible files such as Adobe Illustrator, so these files are now previewed.

## Testing
Added a test that verifies an attached `.ai` file saved in the PDF compatible format is rendered correctly as a PDF preview.

## References
- https://www.redmine.org/issues/44362